### PR TITLE
Add large z-index so not hidden

### DIFF
--- a/example/assets/styles/modal.css
+++ b/example/assets/styles/modal.css
@@ -23,6 +23,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  /* Arbitrarily large z-index because, when used with other libraries that
+   * use z-indexing, the micromodal can be hidden
+   */
+  z-index: 1000;
 }
 
 .modal__container {


### PR DESCRIPTION
When micromodal is used in combination with other libraries (originally found when used with fullcalendar) that use `z-index`ing, it can be hidden. This adds a (arbitrarily) large z-index so it is always visible.

Resolves ghosh/Micromodal#152